### PR TITLE
Revert remove order to avoid to skip indexes

### DIFF
--- a/src/model/collection.js
+++ b/src/model/collection.js
@@ -37,7 +37,7 @@ function $CollectionFactory (BaseModel) {
         },
         set: function (models, options) {
             var i;
-            for (i = 0; i < this.models.length; i++) {
+            for (i=this.models.length-1; i>=0; i--) {
                 this.removeIndex(i);
             }
 


### PR DESCRIPTION
Actually the function `set` doe not remove **all** items because the method `removeIndex` splice the property used in the loop.
IE: After removing the item N°0, the loop will try to remove the item N°1 which is now N°0 due to the splice.

This PR just revert the loop to start from the end.

An other alternative could be

```
while (this.models.length>0) {
  this.removeIndex(0);
}
```

or faster

```
this.models.length = 0;
this.attributes.length = 0;
```

as you want
